### PR TITLE
Remove points outside extent of enviro data

### DIFF
--- a/R/rangebag.R
+++ b/R/rangebag.R
@@ -102,6 +102,14 @@ rangebag.SpatRaster <- function(x, p,
 
   # Select data from cells in x corresponding to each occurrence point in p
   fit_idx <- terra::cellFromXY(x, p[, c("lon", "lat")])
+  if(any(is.na(fit_idx))) { # Remove any points outside the extent of the data
+    n_outside <- length(which(is.na(fit_idx)))
+    warning(sprintf(
+      "%i points %s outside the extent of the environmental data and will be ignored",
+      n_outside, if(n_outside > 0) "are" else "is"
+    ), call. = FALSE)
+    fit_idx <- fit_idx[!is.na(fit_idx)]
+  }
   if (limit_occur) { # limit to one occurrence per cell
     fit_idx <- unique(fit_idx)
   }

--- a/R/rangebag.R
+++ b/R/rangebag.R
@@ -7,7 +7,8 @@
 #'   \code{raster::Raster*} (with any CRS), or a \code{data.frame} with
 #'   WGS84 \emph{lon} and \emph{lat} columns.
 #' @param p Species occurrence data as a \code{data.frame} (or \code{matrix})
-#'   with WGS84 \emph{lon} and \emph{lat} columns.
+#'   with WGS84 \emph{lon} and \emph{lat} columns. Any points outside the extent
+#'   of \code{x} will be ignored.
 #' @param n_models Number of convex hull models to build in sampled environment
 #'   space (default = 100).
 #' @param n_dim Number of dimensions (variables) of sampled convex hull models


### PR DESCRIPTION
Fixes bug where `fit_idx` would include `NA` if any points are outside the extent of the enviro rasts, and those would be passed to ` as.data.frame(x[fit_idx])` (reducing to a single `NA` first if `limit_occur` is TRUE). 

This change drops those points and issues a warning indicating the number of ignored points.