### PR TITLE
Remove default n in call to blocks; bump to 0.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bssdm
 Title: Biosecurity Species Distribution Modelling
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("Sean", "Haythorne", email = "sean.haythorne@unimelb.edu.au", role = c("aut", "cre")),
     person("James", "Camac", email = "james.camac@unimelb.edu.au", role = c("aut")),
@@ -12,7 +12,7 @@ URL: https://github.com/cebra-analytics/bssdm
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.3
 Imports:
     doParallel (>= 1.0.16),
     foreach (>= 1.5.1),

--- a/R/mess.R
+++ b/R/mess.R
@@ -121,11 +121,13 @@ mess.SpatRaster <- function(x, ref, full = FALSE, filename = "", ...) {
     out_sim <- terra::init(x, NA)
     names(out_sim) <- cols
   }
-  out_min <- terra::init(x[[1]], NA)
-  names(out_min) <- "mess"
+  out_min <- setNames(terra::init(x[[1]], NA), "mess")
+  terra::varnames(out_min) <- "mess"
   out_mod <- terra::init(x[[1]], NA)
+  terra::varnames(out_mod) <- "mod"
   out_mos <- terra::init(x[[1]], NA)
-  
+  terra::varnames(out_mos) <- "mos"
+
   # Handle raster data in blocks
   x_blocks <- terra::blocks(x, n = 8)
   n_blocks <- x_blocks$n

--- a/R/mess.R
+++ b/R/mess.R
@@ -134,9 +134,7 @@ mess.SpatRaster <- function(x, ref, full = FALSE, filename = "", ...) {
   if (isTRUE(full)) {
     invisible(terra::writeStart(out_sim, filename = "", ...))
   }
-  invisible(terra::writeStart(out_min, 
-                              filename = if (filename != "") filename else "", 
-                              ...))
+  invisible(terra::writeStart(out_min, filename = filename, ...))
   invisible(terra::writeStart(out_mod, filename = "", ...))
   invisible(terra::writeStart(out_mos, filename = "", ...))
   

--- a/R/mess.R
+++ b/R/mess.R
@@ -129,7 +129,7 @@ mess.SpatRaster <- function(x, ref, full = FALSE, filename = "", ...) {
   terra::varnames(out_mos) <- "mos"
 
   # Handle raster data in blocks
-  x_blocks <- terra::blocks(x, n = 8)
+  x_blocks <- terra::blocks(x, ...)
   n_blocks <- x_blocks$n
   terra::readStart(x)
   


### PR DESCRIPTION
Key change in `mess()` is:

`x_blocks <- terra::blocks(x, n = 8)` -> `x_blocks <- terra::blocks(x, ...)`

which enables user-specified `n` in the call to `terra::blocks`.  With the previous default n=8, raster corruption occurred in some cases, with twice the intended number of elements being assigned to the resulting rasters.